### PR TITLE
Ignore processing of bot's own messages.

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function receiveMessage(req, res, next){
 	var message_instances = req.body.entry[0].messaging;
 	message_instances.forEach(function(instance){
 		var sender = instance.sender.id;
-		if(instance.message && instance.message.text) {
+		if(instance.message && instance.message.text  && !instance.message.is_echo) {
 			var msg_text = instance.message.text;
 			sendMessage(sender, msg_text, true);
 		}


### PR DESCRIPTION
For every message response, the bot processes it's own message aswell and logs a sender ID not found, there the sender ID would be the bot ID. So, It's better to ignore the bot's message before processing its response.